### PR TITLE
Fix: Clean up repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ src/sibyllai_core/thirdparty/music2emo/dataset/*/
 *.ckpt
 *.pkl
 *.joblib
+*.mov


### PR DESCRIPTION
This commit addresses several issues in the repository:

- Ensures .DS_Store files are ignored.
- Removes examples/data/trailer.mov from git history to reduce repository size.
- Adds *.mov to .gitignore to prevent large binary files from being committed.
- Investigated the src/sibyllai_core/thirdparty/music2emo/ directory and confirmed it is not a submodule but part of the project's codebase.