### PR TITLE
Fix music analysis failure for segment one

### DIFF
--- a/src/sibyllai_core/thirdparty/music2emo/utils/mir_eval_modules.py
+++ b/src/sibyllai_core/thirdparty/music2emo/utils/mir_eval_modules.py
@@ -29,17 +29,38 @@ def idx2voca_chord():
 def audio_file_to_features(audio_file, config):
     original_wav, sr = librosa.load(audio_file, sr=config.mp3['song_hz'], mono=True)
     currunt_sec_hz = 0
+
+    # Pre-initialise so that the variable is **always** defined, preventing
+    # `UnboundLocalError` when the audio is shorter than a single window.
+    feature = None
+
+    # Process fixed-length chunks first
     while len(original_wav) > currunt_sec_hz + config.mp3['song_hz'] * config.mp3['inst_len']:
         start_idx = int(currunt_sec_hz)
         end_idx = int(currunt_sec_hz + config.mp3['song_hz'] * config.mp3['inst_len'])
-        tmp = librosa.cqt(original_wav[start_idx:end_idx], sr=sr, n_bins=config.feature['n_bins'], bins_per_octave=config.feature['bins_per_octave'], hop_length=config.feature['hop_length'])
-        if start_idx == 0:
-            feature = tmp
-        else:
-            feature = np.concatenate((feature, tmp), axis=1)
+        tmp = librosa.cqt(
+            original_wav[start_idx:end_idx],
+            sr=sr,
+            n_bins=config.feature['n_bins'],
+            bins_per_octave=config.feature['bins_per_octave'],
+            hop_length=config.feature['hop_length'],
+        )
+
+        # Initialise or append depending on whether this is the first block
+        feature = tmp if feature is None else np.concatenate((feature, tmp), axis=1)
+
         currunt_sec_hz = end_idx
-    tmp = librosa.cqt(original_wav[currunt_sec_hz:], sr=sr, n_bins=config.feature['n_bins'], bins_per_octave=config.feature['bins_per_octave'], hop_length=config.feature['hop_length'])
-    feature = np.concatenate((feature, tmp), axis=1)
+
+    # Handle the trailing (or entire) remainder of the audio
+    tmp = librosa.cqt(
+        original_wav[currunt_sec_hz:],
+        sr=sr,
+        n_bins=config.feature['n_bins'],
+        bins_per_octave=config.feature['bins_per_octave'],
+        hop_length=config.feature['hop_length'],
+    )
+
+    feature = tmp if feature is None else np.concatenate((feature, tmp), axis=1)
     feature = np.log(np.abs(feature) + 1e-6)
     feature_per_second = config.mp3['inst_len'] / config.model['timestep']
     song_length_second = len(original_wav)/config.mp3['song_hz']


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Initialize `feature` in `audio_file_to_features` to prevent `UnboundLocalError` for short audio inputs.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, `feature` was only assigned within a loop that might not execute if the audio was shorter than a single processing window, leading to an `UnboundLocalError`. This ensures `feature` is always defined before use.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7722e97-2f1a-4c76-b8b8-5e4f940708eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7722e97-2f1a-4c76-b8b8-5e4f940708eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>